### PR TITLE
Savitzky-Golay Filter and Find Dips

### DIFF
--- a/centrodip/centrodip.py
+++ b/centrodip/centrodip.py
@@ -508,7 +508,7 @@ def main():
         "--mdr-threshold",
         type=float,
         default=1,
-        help="Scalar factor to determine minimum height of an MDR. Scalar is multiplied by the smoothed data's median. Higher values decrease leniency of MDR calls. (default: 0.5)",
+        help="Number of standard deviations from the mean smoothed data to consider the minimum MDR height. Lower values increase leniency of MDR calls. (default: 1)",
     )
     argparser.add_argument(
         "--prominence-constant",
@@ -520,7 +520,7 @@ def main():
         "--transition-threshold",
         type=int,
         default=0,
-        help="Scalar factor to decide the threshold of an MDR Transition call. Scalar is multiplied by smoothed data's median. (default: 1)",
+        help="Number of standard deviations from the mean smoothed data to consider the transition cutoff. (default: 0)",
     )
     argparser.add_argument(
         "--significance",
@@ -622,7 +622,6 @@ def main():
                     file.write("\t".join(line) + "\n")
         else:
             return
-
 
     bed_parser = BedParse(
         mod_code=args.mod_code,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="centrodip",
-    version="0.1.0",
+    version="0.0.1",
     description="Find hypomethylated regions in centromeres",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -29,7 +29,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8, <3.13",
+    python_requires=">=3.8",
     extras_require={
         "dev": [
             "pytest",

--- a/tests/test_centrodip.py
+++ b/tests/test_centrodip.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from centrodip.centrodip import BedParser, CentroDip
+from centrodip.centrodip import BedParse, CentroDip
 
 
 class TestMatrix:
@@ -9,9 +9,9 @@ class TestMatrix:
         """Fixture to set up test data and parser"""
         test_data_dir = os.path.join("tests", "data")
 
-        bed_parser = BedParser(
+        bed_parser = BedParse(
             mod_code="m",
-            methyl_bedgraph=False,
+            bedgraph=False,
             region_edge_filter=0,
         )
 
@@ -28,33 +28,33 @@ class TestMatrix:
         """Fixture for matrix calculator"""
         return CentroDip(
             window_size=101,
-            step_size=1,
-            min_valid_cov=1,
-            stat="mannwhitneyu",
-            cdr_p=0.0000001,
-            transition_p=0.01,
-            min_sig_cpgs=50,
-            merge_distance=50,
+            mdr_threshold=1,
+            transition_threshold=0,
+            prominence_constant=0.5,
+            significance=1e-10,
+            min_size=1000,
+            min_cov=1,
             enrichment=False,
             threads=4,
-            cdr_color="50,50,255",
-            transition_color="150,150,150",
-            output_label="subCDR",
+            mdr_color='50,50,255',
+            transition_color='150,150,255',
+            low_cov_color='211,211,211',
+            label='subCDR'
         )
 
-    def test_centro_dip(self, test_data, centro_dip):
+    def test_centrodip(self, test_data, centro_dip):
         """Test making matrices"""
         (
-            cdrs_all_chroms,
-            low_cov_all_chroms,
-            methylation_sig_all_chroms,
+            cdrs_per_region,
+            low_cov_per_region,
+            methylation_per_region,
         ) = centro_dip.centrodip_all_chromosomes(
-            regions_all_chroms=test_data[0],
-            methylation_all_chroms=test_data[1]
+            methylation_per_region=test_data[1],
+            regions_per_chrom=test_data[0]
         )
 
-        assert isinstance(cdrs_all_chroms, dict)
-        assert isinstance(methylation_sig_all_chroms, dict)
-        assert len(cdrs_all_chroms) == 1
-        assert len(methylation_sig_all_chroms) == 1
-        assert len(methylation_sig_all_chroms["chrX_MATERNAL"]["p-values"]) == 62064
+        assert isinstance(cdrs_per_region, dict)
+        assert isinstance(methylation_per_region, dict)
+        assert len(cdrs_per_region) == 1
+        assert len(methylation_per_region) == 1
+        assert len(methylation_per_region["chrX_MATERNAL:57866525-60979767"]["fraction_modified"]) == 62064

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from centrodip.centrodip import BedParser
+from centrodip.centrodip import BedParse
 
 
 class TestParser:
@@ -10,9 +10,9 @@ class TestParser:
 
     @pytest.fixture
     def bed_parser(self):
-        return BedParser(
+        return BedParse(
             mod_code="m",
-            methyl_bedgraph=False,
+            bedgraph=False,
             region_edge_filter=0,
         )
 
@@ -29,7 +29,7 @@ class TestParser:
         empty_file = os.path.join(test_data_dir, "empty.bed")
 
         result1 = bed_parser.read_and_filter_regions(str(empty_file))
-        result2 = bed_parser.read_and_filter_regions(str(empty_file))
+        result2 = bed_parser.read_and_filter_methylation(str(empty_file), result1)
 
         assert len(result1) == 0
         assert len(result2) == 0
@@ -48,16 +48,20 @@ class TestParser:
     def test_bedmethyl_bedfile(self, test_data_dir, bed_parser):
         """Test basic bedmethyl reading functionality"""
         sample_bedmethyl_bed = os.path.join(test_data_dir, "bedmethyl_test.bed")
+        sample_censat_bed = os.path.join(test_data_dir, "censat_test.bed")
+
+        regions_dict = bed_parser.read_and_filter_regions(sample_censat_bed)
         results = bed_parser.read_and_filter_methylation(
-            sample_bedmethyl_bed
+            sample_bedmethyl_bed,
+            regions_dict
         )
 
-        assert list(results.keys())[0] == "chrX_MATERNAL"
+        assert list(results.keys())[0] == "chrX_MATERNAL:57866525-60979767"
         assert len(list(results.keys())) == 1
 
-        assert len(results["chrX_MATERNAL"]["starts"]) == 62064
-        assert len(results["chrX_MATERNAL"]["ends"]) == 62064
-        assert len(results["chrX_MATERNAL"]["fraction_modified"]) == 62064
+        assert len(results["chrX_MATERNAL:57866525-60979767"]["starts"]) == 62064
+        assert len(results["chrX_MATERNAL:57866525-60979767"]["ends"]) == 62064
+        assert len(results["chrX_MATERNAL:57866525-60979767"]["fraction_modified"]) == 62064
 
     def test_chrom_dict_len(self, test_data_dir, bed_parser):
         """Test basic bedmethyl reading functionality"""


### PR DESCRIPTION
Changed the logic to be as follows:
1.  Smooth the data using scipy `scipy.signal.savgol_filter`
2. Use `scipy.signal.find_peaks` to detect the dips in methylation pileup. 
 - The height threshold for this can be adjusted with the `--mdr-threshold`. This is the number of standard deviations to be subtracted from the mean smoothed data to consider as minimum MDR height. Lower values increase leniency of MDR calls.
 - The prominence threshold can be adjusted with `--prominence-constant`. This value is a scalar factor used to decide the prominence required for an MDR peak. Scalar is multiplied by smoothed data's difference in the 99th and 1st percentiles. Lower values increase leniency of MDR calls.
3. Extend the edges of dips until you reach an instance that is greater than or equal to `--mdr-threshold * (stdev of smoothed data) + mean of smoothed data`, transitions follow the same logic but their threshold is set by `--transition-threshold`
4. Remove MDR portions/transitons
 - that are below `--min-size`
 - have a pvalue over `--significance` when performing a KS test of the raw values vs the entire region
 - where they overlap with a low coverage region (determined by `--min-cov`)