### PR TITLE
version 1.0.1

### DIFF
--- a/centrodip/__init__.py
+++ b/centrodip/__init__.py
@@ -1,3 +1,3 @@
 # centrodip/__init__.py
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/centrodip/detect_dips.py
+++ b/centrodip/detect_dips.py
@@ -126,12 +126,14 @@ def find_dip_centers(
             smoothed_methylation,
             prominence=data_prominence_threshold,
             height=np.percentile(smoothed_methylation, q=(1-height)*100),
+            wlen=len(smoothed_methylation)
         )
     else:
         centers, _ = signal.find_peaks(
             -smoothed_methylation,
             prominence=data_prominence_threshold,
             height=-np.percentile(smoothed_methylation, q=(height)*100),
+            wlen=len(smoothed_methylation)
         )
 
     return centers.astype(int)

--- a/centrodip/filter_dips.py
+++ b/centrodip/filter_dips.py
@@ -8,10 +8,33 @@ from centrodip.bedtable import BedTable
 
 def filterDips(
     dips: BedTable,
+    regions: BedTable,
     min_size: int,
     min_score: float,
     cluster_distance: int,
 ) -> BedTable:
+
+    # region span filter - keep only dips that are entirely within a single region
+    if regions is not None and len(regions._records) > 0:
+        filtered_recs = []
+        for dip_rec in dips._records:
+            dip_chrom = dip_rec.chrom
+            dip_start = dip_rec.start
+            dip_end = dip_rec.end
+
+            # Check if dip is within any region
+            within_region = False
+            for region_rec in regions._records:
+                if region_rec.chrom != dip_chrom:
+                    continue
+                if region_rec.start <= dip_start and dip_end <= region_rec.end:
+                    within_region = True
+                    break
+
+            if within_region:
+                filtered_recs.append(dip_rec)
+
+        dips = BedTable(filtered_recs, inferred_kind="bed", inferred_ncols=6)
 
     # size filter - remove dip regions smaller than min_size
     # convert back to BedTable

--- a/centrodip/main.py
+++ b/centrodip/main.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import argparse
+from importlib.metadata import version, PackageNotFoundError
 
 import concurrent.futures
 
@@ -184,8 +185,22 @@ def main():
         default=False,
         help="Dumps smoothed methylation values, their derivatives, methylation peaks, and derivative peaks. Each to separate BED/BEDGraph files. (default: False)",
     )
+    other_arguments_group.add_argument(
+        "--version",
+        action="version",
+        version=f"centrodip {version('centrodip')}"
+    )
 
     args = parser.parse_args()
+
+    # print version if --version is passed in
+    if args.version:
+        try:
+            v = version("centrodip")
+        except PackageNotFoundError:
+            v = "unknown"
+        print(f"centrodip version: {v}")
+        return
 
     # -------------------------
     # Load files

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "centrodip" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="centrodip",
-    version="1.0.0",
+    version="1.0.1",
     description="Find hypomethylated regions in centromeres",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/tests/test_filter_dips.py
+++ b/tests/test_filter_dips.py
@@ -24,7 +24,8 @@ def _rec(chrom: str, start: int, end: int, score: int | None) -> IntervalRecord:
 
 def test_filterDips_empty_returns_empty():
     dips = _bt()
-    out = filterDips(dips, min_size=1000, min_score=100, cluster_distance=500_000)
+    regions = _bt()
+    out = filterDips(dips, regions, min_size=1000, min_score=100, cluster_distance=500_000)
     assert isinstance(out, BedTable)
     assert len(out._records) == 0
 
@@ -34,7 +35,10 @@ def test_filterDips_size_filter_removes_small():
         _rec("chr1", 0, 500, 200),      # len 500 -> removed
         _rec("chr1", 1000, 2500, 200),  # len 1500 -> kept
     )
-    out = filterDips(dips, min_size=1000, min_score=0, cluster_distance=-1)
+    regions = _bt(
+        _rec("chr1", 0, 3000, None),     # region covering both dips
+    )
+    out = filterDips(dips, regions, min_size=1000, min_score=0, cluster_distance=-1)
     assert [(r.start, r.end) for r in out._records] == [(1000, 2500)]
 
 
@@ -44,7 +48,10 @@ def test_filterDips_score_filter_removes_low_and_none_scores():
         _rec("chr1", 3000, 5000, 99),  # removed (<100)
         _rec("chr1", 6000, 9000, 100), # kept
     )
-    out = filterDips(dips, min_size=0, min_score=100, cluster_distance=-1)
+    regions = _bt(
+        _rec("chr1", 0, 10_000, None),  #
+    )
+    out = filterDips(dips, regions, min_size=0, min_score=100, cluster_distance=-1)
     assert [(r.start, r.end, r.score) for r in out._records] == [(6000, 9000, 100)]
 
 
@@ -57,7 +64,10 @@ def test_filterDips_clusterFilter_applied_after_other_filters():
         _rec("chr1", 1_010_000, 1_011_000, 200),  # cluster B
         _rec("chr1", 1_020_000, 1_021_000, 200),  # cluster B
     )
-    out = filterDips(dips, min_size=0, min_score=0, cluster_distance=50_000)
+    regions = _bt(
+        _rec("chr1", 0, 2_000_000, None),
+    )
+    out = filterDips(dips, regions, min_size=0, min_score=0, cluster_distance=50_000)
     # Expect cluster A chosen (mean 800 > 200)
     assert [(r.start, r.end) for r in out._records] == [(0, 1000), (10_000, 11_000)]
 
@@ -129,7 +139,7 @@ def test_filter_dips_crossing_region_gaps_drops_spanning_dip():
         IntervalRecord("chr1", 150, 350, name="BAD", score=900, strand="."),  # spans 200-300 gap
     ], inferred_kind="bed", inferred_ncols=6)
 
-    out = filter_dips_crossing_region_gaps(dips, regions)
+    out = filterDips(dips, regions, 1, 100, 1000)
     names = [r.name for r in out._records]
     assert "BAD" not in names
     assert set(names) == {"ok1", "ok2"}


### PR DESCRIPTION
* Added `wlen=len(methylation)` to `scipy.signal.find_peaks()` to use a more global approach to peak calling. (This was previously implemented, but reverted in v1.0.0, bringing it back in v1.0.1)
* Added a `--version` flag to argparse. 
* Updated version information to be 1.0.1.